### PR TITLE
Railway: add config-as-code, fix pnpm prepare, and split frontend/backend deploys

### DIFF
--- a/frontend/railway.json
+++ b/frontend/railway.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
-  "build": { "buildCommand": "pnpm install && pnpm build" },
-  "deploy": { "startCommand": "pnpm start -- -p $PORT" }
+  "build": { "buildCommand": "pnpm install --frozen-lockfile && pnpm build" },
+  "deploy": { "startCommand": "pnpm dlx next start -p $PORT" }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "setup": "cd backend && bundle exec rails js:routes:typescript",
     "lint-fast": "DISABLE_TYPE_CHECKED=1 pnpm eslint",
     "build-next": "pnpm next build frontend --no-lint",
-    "prepare": "git config --local core.hooksPath .githooks"
+    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config --local core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.688.0",
@@ -159,6 +159,11 @@
     },
     "onlyBuiltDependencies": [
       "bcrypt"
-    ]
+    ],
+    "allowedScripts": {
+      "esbuild": true,
+      "puppeteer": true,
+      "sharp": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- guard the root prepare script so it no-ops outside git repos and whitelist required pnpm postinstall scripts
- ensure the frontend Railway service installs with a frozen lockfile and starts Next.js via pnpm dlx

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd98c2910c8332beb8213160ba032b