### PR TITLE
Configure frontend for Railway deployment

### DIFF
--- a/docs/railway-deploy.md
+++ b/docs/railway-deploy.md
@@ -30,7 +30,7 @@
 
 ### Frontend (Next.js)
 
-- `NEXT_PUBLIC_API_URL=https://<rails-service>.up.railway.app`
+- `NEXT_PUBLIC_API_URL=https://<rails-service>.up.railway.app` (used by the API proxy & CSP)
 - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...`
 
 ## Custom Domains

--- a/frontend/app/[...rails]/route.ts
+++ b/frontend/app/[...rails]/route.ts
@@ -9,16 +9,22 @@ async function handler(req: Request) {
   if (!routes.some((route) => url.pathname.match(route))) {
     throw notFound();
   }
-  switch (process.env.VERCEL_ENV) {
-    case "production":
-      url.host = "api.flexile.com";
-      break;
-    case "preview":
-      url.hostname = `flexile-pipeline-pr-${process.env.VERCEL_GIT_PULL_REQUEST_ID}.herokuapp.com`;
-      break;
-    default:
-      url.port = process.env.RAILS_ENV === "test" ? "3101" : "3001";
-      url.protocol = "http";
+  const configuredApiUrl = env.NEXT_PUBLIC_API_URL ? new URL(env.NEXT_PUBLIC_API_URL) : null;
+  if (configuredApiUrl) {
+    url.protocol = configuredApiUrl.protocol;
+    url.host = configuredApiUrl.host;
+  } else {
+    switch (process.env.VERCEL_ENV) {
+      case "production":
+        url.host = "api.flexile.com";
+        break;
+      case "preview":
+        url.hostname = `flexile-pipeline-pr-${process.env.VERCEL_GIT_PULL_REQUEST_ID}.herokuapp.com`;
+        break;
+      default:
+        url.port = process.env.RAILS_ENV === "test" ? "3101" : "3001";
+        url.protocol = "http";
+    }
   }
 
   const session = await getServerSession(authOptions);

--- a/frontend/env/client.ts
+++ b/frontend/env/client.ts
@@ -3,10 +3,12 @@ import { z } from "zod";
 // Next inlines env variables in the client bundle, so we need to list them out here
 const env = {
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
 };
 
 export default z
   .object({
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string(),
+    NEXT_PUBLIC_API_URL: z.string().url().optional(),
   })
   .parse(env);

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -12,12 +12,14 @@ export default function middleware(req: NextRequest) {
   const helperUrls = ["https://help.flexile.com", "wss://xmrztjqxvugqpgvxpmzz.supabase.co/realtime/v1/websocket"].join(
     " ",
   );
+  const apiOrigin = env.NEXT_PUBLIC_API_URL ? new URL(env.NEXT_PUBLIC_API_URL).origin : undefined;
+  const connectSrc = ["'self'", helperUrls, s3Urls, apiOrigin].filter(Boolean).join(" ");
 
   const cspHeader = `
     default-src 'self';
     script-src 'self' 'unsafe-inline' https://js.stripe.com ${NODE_ENV === "production" ? "" : `'unsafe-eval'`};
     style-src 'self' 'unsafe-inline';
-    connect-src 'self' ${helperUrls} ${s3Urls};
+    connect-src ${connectSrc};
     img-src 'self' blob: data: ${s3Urls};
     worker-src 'self' blob:;
     font-src 'self';


### PR DESCRIPTION
## Summary
- allow configuring the Rails proxy via `NEXT_PUBLIC_API_URL` so the frontend can target Railway-hosted APIs
- include the configured API origin in the CSP connect-src directive
- document how the new environment variable is used during Railway deployments

## Testing
- pnpm lint-fast

------
https://chatgpt.com/codex/tasks/task_e_68dd9d70939c833298839125017a38f8