### PR TITLE
Ensure bundler is installed in Railway builds

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "buildCommand": "cd backend && bundle install && bundle exec rails db:prepare"
+    "buildCommand": "cd backend && gem install bundler -v 2.3.11 && bundle _2.3.11_ install && bundle _2.3.11_ exec rails db:prepare"
   },
   "deploy": {
-    "startCommand": "cd backend && bundle exec rails server -b 0.0.0.0 -p $PORT"
+    "startCommand": "cd backend && gem install bundler -v 2.3.11 && bundle _2.3.11_ exec rails server -b 0.0.0.0 -p $PORT"
   }
 }


### PR DESCRIPTION
## Summary
- install the Bundler gem during Railway builds and deploys
- run bundle commands with the required Bundler version 2.3.11

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda0e53d388332934bb2278bdb2534